### PR TITLE
Add site initialization scripts and callout styles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,12 @@
-node_modules
-_site
+node_modules/
+_site/
 .git
 .gitignore
 Dockerfile
 docker-compose.yml
-content
-.obsidian
+content/
+.obsidian/
 README.md
+LICENSE
+setup/
+setup.sh

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,16 @@
+# Site Configuration
+SITE_TITLE=My Site
+SITE_PORT=8080
+
+# Content Configuration
+CONTENT_DIR=./content
+
+# User Configuration
+PUID=1000
+PGID=1000
+TZ=Etc/UTC
+
+# Obsidian Configuration
+ENABLE_OBSIDIAN=true
+OBSIDIAN_PORT=3000
+OBSIDIAN_SYNC_PORT=3001

--- a/content/bundle.css
+++ b/content/bundle.css
@@ -101,3 +101,163 @@ ul.tags {
     list-style-type: none;
     padding: 0;
 }
+
+/**
+ * Color about
+ */
+ :root {
+    --line-height-tight: 1.3;
+    --callout-border-width: 0px;
+    --callout-border-opacity: 0.25;
+    --callout-padding: 12px 12px 12px 24px;
+    --callout-radius: 4px;
+    --callout-title-color: inherit;
+    --callout-title-padding: 0;
+    --callout-title-size: inherit;
+    --callout-title-weight: 600;
+    --callout-content-padding: 0;
+    --callout-content-background: transparent;
+    --callout-blend-mode: var(darken);
+    --callout-info: 8, 109, 221;
+    --callout-todo: 8, 109, 221;
+    --callout-default: 8, 109, 221;
+    --callout-bug: 233, 49, 71;
+    --callout-error: 233, 49, 71;
+    --callout-fail: 233, 49, 71;
+    --callout-success: 8, 185, 78;
+    --callout-example: 120, 82, 238;
+    --callout-important: 0, 191, 188;
+    --callout-summary: 0, 191, 188;
+    --callout-tip: 0, 191, 188;
+    --callout-question: 236, 117, 0;
+    --callout-warning: 236, 117, 0;
+    --callout-quote: 158, 158, 158;
+    --callout-collapse-icon: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iY3VycmVudENvbG9yIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiIgZD0ibTkgMThsNi02bC02LTYiLz48L3N2Zz4=");
+  }
+  
+  .theme-light {
+    --callout-blend-mode: var(darken);
+  }
+  
+  .theme-dark {
+    --callout-blend-mode: var(lighten);
+  }
+  
+  html[data-theme="light"] #app {
+    --callout-blend-mode: var(darken);
+  }
+  
+  html[data-theme="dark"] #app {
+    --callout-blend-mode: var(lighten);
+  }
+  
+  /**
+   * Obsidian callout about
+   * 
+   * The following style is exactly the same as in obsidian
+   */
+  .callout {
+    overflow: hidden;
+    border-style: solid;
+    border-color: rgba(var(--callout-color), var(--callout-border-opacity));
+    border-width: var(--callout-border-width);
+    border-radius: var(--callout-radius);
+    margin: 1em 0;
+    mix-blend-mode: var(--callout-blend-mode);
+    background-color: rgba(var(--callout-color), 0.1);
+    padding: var(--callout-padding);
+    --callout-color: var(--callout-default);
+    --callout-icon: lucide-pencil;
+  }
+  
+  .callout .callout-title {
+    padding: var(--callout-title-padding);
+    display: flex;
+    gap: 4px;
+    font-size: var(--callout-title-size);
+    color: rgb(var(--callout-color));
+    line-height: var(--line-height-tight);
+    align-items: flex-start;
+  }
+  
+  details.callout .callout-title {
+    margin: 0;
+    cursor: pointer;
+  }
+  
+  .callout .callout-title .callout-icon {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+  }
+  
+  .callout .callout-title .callout-title-inner {
+    --font-weight: var(--callout-title-weight);
+    font-weight: var(--font-weight);
+    color: var(--callout-title-color);
+  }
+  
+  .callout .callout-title .callout-fold {
+    background-color: rgb(var(--callout-color));
+    mask-image: var(--callout-collapse-icon);
+    mask-size: 100%;
+    -webkit-mask-image: var(--callout-collapse-icon);
+    -webkit-mask-size: 100%;
+    height: 24px;
+    width: 24px;
+    transition: 100ms ease-in-out;
+  }
+  
+  details[close].callout > .callout-title > .callout-fold {
+    transform: rotate(-90deg);
+  }
+  
+  details[open].callout > .callout-title > .callout-fold {
+    transform: rotate(90deg);
+  }
+  
+  .callout .callout-content {
+    overflow-x: auto;
+    padding: var(--callout-content-padding);
+    background-color: var(--callout-content-background);
+  }
+  
+  .callout[data-callout="todo"] {
+    --callout-color: var(--callout-todo);
+    --callout-icon: lucide-check-circle-2;
+  }
+  
+  .callout[data-callout="success"], .callout[data-callout="check"], .callout[data-callout="done"] {
+    --callout-color: var(--callout-success);
+    --callout-icon: lucide-check;
+  }
+  
+  .callout[data-callout="warning"], .callout[data-callout="caution"], .callout[data-callout="attention"] {
+    --callout-color: var(--callout-warning);
+    --callout-icon: lucide-alert-triangle;
+  }
+  
+  .callout[data-callout="danger"], .callout[data-callout="error"] {
+    --callout-color: var(--callout-error);
+    --callout-icon: lucide-zap;
+  }
+  
+  .callout[data-callout="tip"], .callout[data-callout="hint"] {
+    --callout-color: var(--callout-tip);
+    --callout-icon: lucide-flame;
+  }
+  
+  .callout[data-callout="example"] {
+    --callout-color: var(--callout-example);
+    --callout-icon: lucide-list;
+  }
+  
+  .callout[data-callout="abstract"], .callout[data-callout="summary"], .callout[data-callout="tldr"] {
+    --callout-color: var(--callout-summary);
+    --callout-icon: lucide-clipboard-list;
+  }
+  
+  .callout[data-callout="quote"], .callout[data-callout="cite"] {
+    --callout-color: var(--callout-quote);
+    --callout-icon: quote-glyph;
+  }

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,4 +1,6 @@
 const markdownItTaskCheckbox = require('markdown-it-task-checkbox');
+const mdItObsidianCallouts = require('markdown-it-obsidian-callouts');
+
 
 module.exports = (eleventyConfig) => {
   // Add the interlinker plugin for obsidian wikilink support
@@ -10,6 +12,9 @@ module.exports = (eleventyConfig) => {
   // Set the input directory and copy the bundle.css file to the output directory
   eleventyConfig.setInputDirectory("content");
   eleventyConfig.addPassthroughCopy("content/bundle.css");
+
+  // Add the markdown-it-obsidian-callouts plugin to the markdown-it parser
+  eleventyConfig.amendLibrary("md", (mdLib) => mdLib.use(mdItObsidianCallouts));
   // Add the markdown-it-task-checkbox plugin to the markdown-it parser
   eleventyConfig.amendLibrary("md", (mdLib) => mdLib.use(markdownItTaskCheckbox));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@11ty/eleventy": "^3.0.0",
         "@photogabble/eleventy-plugin-interlinker": "^1.1.0",
+        "markdown-it-obsidian-callouts": "^0.3.1",
         "markdown-it-task-checkbox": "^1.0.6"
       }
     },
@@ -1708,6 +1709,17 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-obsidian-callouts": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-obsidian-callouts/-/markdown-it-obsidian-callouts-0.3.1.tgz",
+      "integrity": "sha512-MCvbHofaDxUD9hwrQg9+62Yq5Ev1K2glr5ogUxvFWm7WGG3SKqC90/ozWZ/ofqUvD5iw2KLElSWLHvL1crUeqA==",
+      "funding": {
+        "url": "https://www.buymeacoffee.com/ebullient"
+      },
+      "peerDependencies": {
+        "markdown-it": "^14.0.0"
       }
     },
     "node_modules/markdown-it-task-checkbox": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@11ty/eleventy": "^3.0.0",
     "@photogabble/eleventy-plugin-interlinker": "^1.1.0",
+    "markdown-it-obsidian-callouts": "^0.3.1",
     "markdown-it-task-checkbox": "^1.0.6"
   }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,33 @@
+
+#!/bin/bash
+
+set -e
+
+source setup/config.sh
+source setup/utils.sh
+
+echo "🦊 Site Setup Wizard"
+echo "===================="
+
+check_prerequisites
+
+get_user_config
+
+create_directories
+
+write_env_file
+
+envsubst < "setup/templates/docker-compose.yml.template" > "docker-compose.yml"
+
+if [ "$ENABLE_OBSIDIAN" = "y" ]; then
+    docker-compose --profile obsidian up -d
+else
+    docker-compose up -d
+fi
+
+echo "✨ Setup complete!"
+echo "Site available at: http://localhost:${SITE_PORT}"
+if [ "$ENABLE_OBSIDIAN" = "y" ]; then
+    echo "Obsidian interface at: http://localhost:${OBSIDIAN_PORT}"
+    echo "Configure Obsidian sync in the web interface to start syncing your notes."
+fi

--- a/setup/config.sh
+++ b/setup/config.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+get_user_config() {
+    read -p "Enter site title [My Site]: " SITE_TITLE
+    SITE_TITLE=${SITE_TITLE:-"My Site"}
+    
+    read -p "Enter site port [8080]: " SITE_PORT
+    SITE_PORT=${SITE_PORT:-8080}
+
+    read -p "Enter content directory path [./content]: " CONTENT_DIR
+    CONTENT_DIR=${CONTENT_DIR:-"./content"}
+
+    PUID=$(id -u)
+    PGID=$(id -g)
+    
+    read -p "Enter timezone [Etc/UTC]: " TZ
+    TZ=${TZ:-"Etc/UTC"}
+
+    read -p "Enable Obsidian sync? [Y/n]: " ENABLE_OBSIDIAN
+    ENABLE_OBSIDIAN=${ENABLE_OBSIDIAN:-"y"}
+    ENABLE_OBSIDIAN=$(echo "$ENABLE_OBSIDIAN" | tr '[:upper:]' '[:lower:]')
+}
+
+write_env_file() {
+    envsubst < "setup/templates/.env.template" > ".env"
+}

--- a/setup/templates/docker-compose.yml.template
+++ b/setup/templates/docker-compose.yml.template
@@ -1,0 +1,37 @@
+
+services:
+  site:
+    build: .
+    container_name: site
+    ports:
+      - "${SITE_PORT}:8080"
+    volumes:
+      - ${CONTENT_DIR}:/app/content:ro
+      - ./eleventy.config.js:/app/eleventy.config.js:ro
+    restart: unless-stopped
+    user: ${PUID}:${PGID}
+    env_file: .env
+
+  obsidian-sync:
+    image: docker.io/linuxserver/obsidian:latest
+    container_name: obsidian
+    security_opt:
+      - seccomp:unconfined
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+    ports:
+      - "${OBSIDIAN_PORT}:3000"
+      - "${OBSIDIAN_SYNC_PORT}:3001"
+    volumes:
+      - obsidianconfig:/config
+      - ${CONTENT_DIR}:/content
+    shm_size: "1gb"
+    restart: unless-stopped
+    profiles:
+      - obsidian
+
+
+volumes:
+    obsidianconfig:

--- a/setup/utils.sh
+++ b/setup/utils.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+check_prerequisites() {
+    local missing_deps=0
+
+    if ! command -v docker &> /dev/null; then
+        echo "❌ Docker is not installed"
+        missing_deps=1
+    fi
+
+    if ! command -v docker-compose &> /dev/null; then
+        echo "❌ Docker Compose is not installed"
+        missing_deps=1
+    fi
+
+    if ! command -v envsubst &> /dev/null; then
+        echo "❌ envsubst is not installed (package: gettext-base)"
+        missing_deps=1
+    fi
+
+    if [ $missing_deps -eq 1 ]; then
+        exit 1
+    fi
+}
+
+create_directories() {
+    mkdir -p "$CONTENT_DIR"
+    mkdir -p .obsidian/config
+}


### PR DESCRIPTION
Introduce setup scripts and configuration files for site initialization, enhance the .dockerignore, and implement callout styles with theming support in CSS. Additionally, integrate the markdown-it-obsidian-callouts plugin and update dependencies.